### PR TITLE
updating namespace test to work with Steal 0.16 or Steal 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 addons:
-  firefox: "latest"
+  firefox: "51.0"

--- a/can-types_test.js
+++ b/can-types_test.js
@@ -52,7 +52,8 @@ QUnit.test('should throw if can-namespace.types is already defined', function() 
 		start();
 	})
 	.catch(function(err) {
-		ok(err && err.message.indexOf('can-types') >= 0, 'should throw an error about can-types');
+		var errMsg = err && err.message || err;
+		ok(errMsg.indexOf('can-types') >= 0, 'should throw an error about can-types');
 		start();
 	});
 });


### PR DESCRIPTION
closes https://github.com/canjs/can-types/issues/16.