### PR TITLE
Add @package to the docs

### DIFF
--- a/can-types.js
+++ b/can-types.js
@@ -6,6 +6,7 @@ var dev = require('can-util/js/dev/dev');
 /**
  * @module {Object} can-types
  * @parent can-infrastructure
+ * @package ./package.json
  * @description A stateful container for CanJS type information.
  *
  * @body


### PR DESCRIPTION
This fixes an issue with the GitHub star and npm download buttons not appearing in the rendered canjs.com docs.