### PR TITLE
can-util is a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "build": "node build.js",
-    "document": "documentjs",
-    "develop": "done-serve --static --develop --port 8080"
+    "build": "node build.js"
   },
   "main": "can-types",
   "keywords": [
@@ -40,10 +38,6 @@
     "can-util": "^3.9.0"
   },
   "devDependencies": {
-    "documentjs": "^0.4.2",
-    "done-serve": "^1.2.0",
-    "donejs-cli": "^1.0.1",
-    "generator-donejs": "^1.0.5",
     "jshint": "^2.9.1",
     "steal": "^1.2.10",
     "steal-qunit": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   ],
   "dependencies": {
     "can-namespace": "1.0.0",
-    "can-reflect": "^1.0.0-pre.1",
-    "can-symbol": "^1.0.0-pre.0",
+    "can-reflect": "^1.0.0",
+    "can-symbol": "^1.0.0",
     "can-util": "^3.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   "dependencies": {
     "can-namespace": "1.0.0",
     "can-reflect": "^1.0.0-pre.1",
-    "can-symbol": "^1.0.0-pre.0"
+    "can-symbol": "^1.0.0-pre.0",
+    "can-util": "^3.9.0"
   },
   "devDependencies": {
-    "can-util": "^3.9.0-pre.2",
     "documentjs": "^0.4.2",
     "done-serve": "^1.2.0",
     "donejs-cli": "^1.0.1",


### PR DESCRIPTION
Fix for the `can-reflect` changes; `can-util` is a normal dependency, not just dev.