### PR TITLE
remove deprecated stuff

### DIFF
--- a/can-types.js
+++ b/can-types.js
@@ -1,7 +1,4 @@
 var namespace = require('can-namespace');
-var canReflect = require('can-reflect');
-var canSymbol = require('can-symbol');
-var dev = require('can-util/js/dev/dev');
 
 /**
  * @module {Object} can-types
@@ -24,54 +21,6 @@ var dev = require('can-util/js/dev/dev');
  */
 
 var types = {
-	isMapLike: function(obj){
-		//!steal-remove-start
-		dev.warn('can-types.isMapLike(obj) is deprecated, please use `canReflect.isObservableLike(obj) && canReflect.isMapLike(obj)` instead.');
-		//!steal-remove-end
-		return canReflect.isObservableLike(obj) && canReflect.isMapLike(obj);
-	},
-
-	isListLike: function(obj){
-		//!steal-remove-start
-		dev.warn('can-types.isListLike(obj) is deprecated, please use `canReflect.isObservableLike(obj) && canReflect.isListLike(obj)` instead.');
-		//!steal-remove-end
-		return canReflect.isObservableLike(obj) && canReflect.isListLike(obj);
-	},
-
-	isPromise: function(obj){
-		//!steal-remove-start
-		dev.warn('can-types.isPromise is deprecated, please use canReflect.isPromise instead.');
-		//!steal-remove-end
-		return canReflect.isPromise(obj);
-	},
-
-	isConstructor: function(func){
-		//!steal-remove-start
-		dev.warn('can-types.isConstructor is deprecated, please use canReflect.isConstructorLike instead.');
-		//!steal-remove-end
-		return canReflect.isConstructorLike(func);
-	},
-
-	isCallableForValue: function(obj){
-		//!steal-remove-start
-		dev.warn('can-types.isCallableForValue(obj) is deprecated, please use `canReflect.isFunctionLike(obj) && !canReflect.isConstructorLike(obj)` instead.');
-		//!steal-remove-end
-		return obj && canReflect.isFunctionLike(obj) && !canReflect.isConstructorLike(obj);
-	},
-
-	isCompute: function(obj){
-		//!steal-remove-start
-		dev.warn('can-types.isCompute is deprecated.');
-		//!steal-remove-end
-		return obj && obj.isComputed;
-	},
-
-	get iterator() {
-		//!steal-remove-start
-		dev.warn('can-types.iterator is deprecated, use `canSymbol.iterator || canSymbol.for("iterator")` instead.');
-		//!steal-remove-end
-		return canSymbol.iterator || canSymbol.for("iterator");
-	},
 	/**
 	 * @property {Map} can-types.DefaultMap DefaultMap
 	 *

--- a/can-types_test.js
+++ b/can-types_test.js
@@ -6,15 +6,6 @@ var clone = require('steal-clone');
 
 QUnit.module('can-types');
 
-QUnit.test('types.isConstructor', function () {
-	var Constructor = function(){};
-	Constructor.prototype.method = function(){};
-
-	ok(types.isConstructor(Constructor));
-	ok(!types.isConstructor(Constructor.prototype.method));
-
-});
-
 // Only run this in an environment with a document
 if(DOCUMENT()) {
 

--- a/package.json
+++ b/package.json
@@ -33,15 +33,13 @@
   ],
   "dependencies": {
     "can-namespace": "1.0.0",
-    "can-reflect": "^1.0.0",
-    "can-symbol": "^1.0.0",
     "can-util": "^3.9.0"
   },
   "devDependencies": {
     "jshint": "^2.9.1",
-    "steal": "^1.2.10",
+    "steal": "^1.5.8",
     "steal-qunit": "^1.0.1",
-    "steal-tools": "^1.1.2",
+    "steal-tools": "^1.8.2",
     "testee": "^0.7.0"
   }
 }


### PR DESCRIPTION
remove deprecated that is not documented anymore and causes warnings while a regular build with steal-tools.

this seems to be a major change since we remove methods.

close https://github.com/donejs/donejs/issues/1012