### PR TITLE
Landscaper: Remove deprecated can-util methods and replace with can-globals

### DIFF
--- a/can-types_test.js
+++ b/can-types_test.js
@@ -1,6 +1,6 @@
 var QUnit = require('steal-qunit');
 var types = require('can-types');
-var DOCUMENT = require('can-util/dom/document/document');
+var DOCUMENT = require('can-globals/document/document');
 var namespace = require('can-namespace');
 var clone = require('steal-clone');
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "can-namespace": "1.0.0",
     "can-reflect": "^1.0.0",
     "can-symbol": "^1.0.0",
-    "can-util": "^3.9.0"
+    "can-util": "^3.9.0",
+    "can-globals": "^0.1.0"
   },
   "devDependencies": {
     "jshint": "^2.9.1",


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.github.com/imaustink/d1faff15b89df8fb7964c5d5c3945e72**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.